### PR TITLE
Update The-REST-API.md

### DIFF
--- a/sphinx-docs/The-REST-API.md
+++ b/sphinx-docs/The-REST-API.md
@@ -39,7 +39,7 @@ curl -H "KEY:$API_KEY" -X POST localhost:8888/plugin/access/exploit -d '{"paw":"
 ```
 > You can optionally POST an obfuscator and/or a facts dictionary with key/value pairs to fill in any variables the chosen ability requires.
 ```
-{"paw":"$PAW","ability_id":"$ABILITY_ID","obfuscator":"base64","facts":[{"name":"username","value":"admin"},{"name":"password", "value":"123"}]}
+{"paw":"$PAW","ability_id":"$ABILITY_ID","obfuscator":"base64","facts":[{"trait":"username","value":"admin"},{"trait":"password", "value":"123"}]}
 ```
 
 ## Adversaries


### PR DESCRIPTION
Fix JSON format for API: caldera/plugins/access/app/access_api.py line 29 https://github.com/mitre/access/blob/fff4c20183cb92862db048f03232f717f43a8282/app/access_api.py#L29 Format uses 'trait' and 'value' as keys not 'name' and 'value'

## Description

(insert summary)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
